### PR TITLE
Update ble-pasv-mqtt-gw.js bug causing crash

### DIFF
--- a/ble-pasv-mqtt-gw.js
+++ b/ble-pasv-mqtt-gw.js
@@ -149,6 +149,7 @@ function extractBTHomeData(payload) {
        }
      }
      if (dataType >-1) {
+       let i = dataType;
        let byteSize = datatypes[i][1];
        let factor   = datatypes[i][3];
        let rawdata = payload.slice(index, index + byteSize);


### PR DESCRIPTION
Inserted row 152 to fix bug causing script to fail.

Script was referencing unset variable i instead of dataType.